### PR TITLE
feat: GUI-Only-eval support

### DIFF
--- a/src/mobile_world/core/runner.py
+++ b/src/mobile_world/core/runner.py
@@ -247,6 +247,7 @@ def run_agent_with_evaluation(
     env_image: str = "mobile_world",
     dry_run: bool = False,
     enable_mcp: bool = False,
+    enable_user_interaction: bool = False,
     max_concurrency: int | None = None,
     shuffle_tasks: bool = False,
     **kwargs,
@@ -293,7 +294,7 @@ def run_agent_with_evaluation(
     if len(tasks) != 0:
         task_list = tasks
     else:
-        task_list = envs[0].get_suite_task_list(enable_mcp=enable_mcp)
+        task_list = envs[0].get_suite_task_list(enable_mcp=enable_mcp, enable_user_interaction=enable_user_interaction)
 
     logger.info("Task list: {} ({} tasks)", task_list, len(task_list))
 

--- a/src/mobile_world/core/subcommands/eval.py
+++ b/src/mobile_world/core/subcommands/eval.py
@@ -126,6 +126,13 @@ def _add_common_arguments(parser: argparse.ArgumentParser) -> None:
         help="Enable MCP server",
     )
     parser.add_argument(
+        "--enable-user-interaction",
+        "--enable_user_interaction",
+        dest="enable_user_interaction",
+        action="store_true",
+        help="Enable user interaction tasks (agent-user-interaction). Default: only GUI-only tasks",
+    )
+    parser.add_argument(
         "--scale-factor",
         "--scale_factor",
         dest="scale_factor",
@@ -220,6 +227,7 @@ async def execute(args: argparse.Namespace) -> None:
         env_image=args.env_image,
         dry_run=args.dry_run,
         enable_mcp=args.enable_mcp,
+        enable_user_interaction=args.enable_user_interaction,
         max_concurrency=args.max_concurrency,
         shuffle_tasks=args.shuffle_tasks,
         scale_factor=getattr(args, "scale_factor", 1000),

--- a/src/mobile_world/runtime/client.py
+++ b/src/mobile_world/runtime/client.py
@@ -175,21 +175,36 @@ class AndroidEnvClient:
             ask_user_response=ask_user_response,
         )
 
-    def get_suite_task_list(self, enable_mcp: bool = False) -> list[str]:
-        """Gets the list of tasks in the suite."""
+    def get_suite_task_list(self, enable_mcp: bool = False, enable_user_interaction: bool = False) -> list[str]:
+        """Gets the list of tasks in the suite.
+        
+        Args:
+            enable_mcp: If True, include agent-mcp tasks. Default False excludes them.
+            enable_user_interaction: If True, include agent-user-interaction tasks. Default False excludes them.
+        
+        Returns:
+            List of task names filtered by the specified criteria.
+            By default (both False), returns only GUI-only tasks.
+        """
         self._ensure_initialized()
 
         response = requests.get(f"{self.base_url}/task/list")
         response.raise_for_status()
         task_list = response.json()
-        if enable_mcp:
-            task_list = [task["name"] for task in task_list]
-        else:
-            task_list = [
-                task["name"] for task in task_list if "agent-mcp" not in task["tags"]
-            ]  # exclude agent-mcp tasks
-
-        return task_list
+        
+        # Filter tasks based on tags
+        filtered_tasks = []
+        gui_only = []
+        for task in task_list:
+            tags = task.get("tags", [])
+            # Skip agent-mcp tasks if not enabled
+            if not enable_mcp and "agent-mcp" in tags:
+                continue
+            # Skip agent-user-interaction tasks if not enabled
+            if not enable_user_interaction and "agent-user-interaction" in tags:
+                continue
+            filtered_tasks.append(task["name"])
+        return filtered_tasks
 
     def get_suite_task_length(self, task_type: str) -> int:
         """Gets the length of the suite of tasks."""


### PR DESCRIPTION
增加GUI-Only (117)任务评估逻辑。

评测GUI-Only 脚本参考:
sudo uv run mw eval \
    --agent_type mai_ui_agent \
    --task ALL \
    --max_round 50 \
    --model_name MAI-UI-8B \
    --llm_base_url  \
    --step_wait_time 3 \
    --log_file_root traj_logs/mai_ui_8b_logs 
    
参数参考: 
--task ALL	只运行 GUI-Only 任务
--task ALL --enable-user-interaction	GUI-Only + User Interaction 任务
--task ALL --enable-mcp	GUI-Only + MCP 任务
--task ALL --enable-mcp --enable-user-interaction	运行所有任务

修改逻辑: 通过任务的tag过滤增加GUI-Only评估，主要逻辑在src/mobile_world/runtime/client.py的L204.
