### PR TITLE
Fix task instruction in mastodon_new_filter,check_conference_duration,read_paper_4

### DIFF
--- a/src/mobile_world/tasks/definitions/calendar/check_conference_duration.py
+++ b/src/mobile_world/tasks/definitions/calendar/check_conference_duration.py
@@ -1,38 +1,5 @@
-# from loguru import logger
-
-# from mobile_world.runtime.controller import AndroidController
-# from mobile_world.tasks.base import BaseTask
-
-
-# class CheckConferenceDurationTask(BaseTask):
-#     """Check how many days of conference meetings were scheduled in October."""
-
-#     goal = "How many days of conference meetings did I schedule in October?"
-#     correct_answer = "12"
-
-#     task_tags = {"lang-en"}
-
-#     app_names = {
-#         "Calendar",
-#     }
-
-#     def initialize_task_hook(self, controller: AndroidController) -> bool:
-#         self.relevant_information = "I always schedule conference meetings in the Calendar app."
-#         return True
-
-#     def is_successful(self, controller: AndroidController) -> float | tuple[float, str]:
-#         self._check_is_initialized()
-
-#         answer = controller.interaction_cache
-
-#         if self.correct_answer in str(answer):
-#             logger.info(f"Correct answer found: {answer}")
-#             return 1.0, "Success"
-#         else:
-#             logger.info(f"Incorrect answer: {answer}")
-#             return 0.0, f"Incorrect answer {answer}, expected {self.correct_answer}"
 from loguru import logger
-
+import re
 from mobile_world.runtime.controller import AndroidController
 from mobile_world.tasks.base import BaseTask
 
@@ -50,7 +17,6 @@ class CheckConferenceDurationTask(BaseTask):
         return True
 
     def is_successful(self, controller: AndroidController) -> float | tuple[float, str]:
-        import re
         self._check_is_initialized()
 
         answer = str(controller.interaction_cache)
@@ -87,52 +53,3 @@ class CheckConferenceDurationTask(BaseTask):
             # Traps like 12:00 or 10/12 have been removed above, so it falls here
             logger.info(f"Incorrect answer (filtered context): {answer}")
             return 0.0, f"Incorrect answer '{answer}', expected '{self.correct_answer}'"
-        
-
-
-# test_cases = [
-#     {
-#         "text": "The total number of conference days is 12.",
-#         "expected": True,
-#     },
-#     {
-#         "text": "12",
-#         "expected": True,
-#     },
-#     {
-#         "text": "I checked the calendar and found 12 meetings in October.",
-#         "expected": True,
-#     },
-#     {
-#         "text": "Count: 12 days",
-#         "expected": True,
-#     },
-#     {
-#         "text": "I found 9 days of meetings.",
-#         "expected": False,
-#     },
-#     {
-#         "text": "There are no meetings.",
-#         "expected": False,
-#     },
-#     {
-#         "text": "I checked until October 12, and found 9 meetings.",
-#         "expected": False,
-#     },
-#     {
-#         "text": "On Oct 12th, there was a meeting. Total count is 1.",
-#         "expected": False,
-#     },
-#     {
-#         "text": "The meeting starts at 12:00 PM. Total days: 5",
-#         "expected": False,
-#     },
-#     {
-#         "text": "Meeting list: 10/12, 10/13. Total is 2 days.",
-#         "expected": False,
-#     },
-#     {
-#         "text": "I found 120 meetings.",
-#         "expected": False,
-#     }
-# ]

--- a/src/mobile_world/tasks/definitions/mastodon/mastodon_new_filter.py
+++ b/src/mobile_world/tasks/definitions/mastodon/mastodon_new_filter.py
@@ -8,11 +8,6 @@ from mobile_world.tasks.base import BaseTask
 
 
 class MastodonNewFilterTask(BaseTask):
-    # goal = (
-    #     "Add a new filter called “Anti-Spoiler-BCS”, "
-    #     "use all the words from the text file named filter_BCS in the documents "
-    #     "folder as blocked keywords, and set it to expire 5 days from today."
-    # )
     goal = (
         "In Mastodon, add a new filter called “Anti-Spoiler-BCS”, "
         "use all the words from the text file named filter_BCS in the documents "

--- a/src/mobile_world/tasks/definitions/native/read_paper_4.py
+++ b/src/mobile_world/tasks/definitions/native/read_paper_4.py
@@ -11,7 +11,6 @@ from mobile_world.tasks.base import BaseTask
 class ReadQwen3PaperTask4(BaseTask):
     """Read the Qwen3-Omini paper and answer a question about Vision encoder size."""
 
-    # goal = "Read the downloaded Qwen3-Omni paper and tell me the size of Vision encoder in Qwen3-Omni-30B-A3B model. The answer should consist of only a single number representing the size in MB."
     goal = "Read the downloaded Qwen3-Omni paper and tell me the size of Vision encoder in Qwen3-Omni-30B-A3B model. Please provide only the numeric value in millions of parameters."
 
     # The correct answer for validation


### PR DESCRIPTION
This PR addresses the issues reported in the recent feedback:
   
   - **MastodonNewFilterTask**: Add "In Mastodon" in front of the sentence.
   - **CheckConferenceDurationTask**: Add regular-expression logic on evaluation and I commented out the original code and added test cases for the logic below.
   - **ReadQwen3PaperTask4**: Add "Please provide only the numeric value in millions of parameters." 
 