### PR TITLE
fix(agents): merge caller extra_body instead of replacing it for kimi-k models

### DIFF
--- a/src/mobile_world/agents/base.py
+++ b/src/mobile_world/agents/base.py
@@ -103,7 +103,13 @@ class BaseAgent(ABC):
                         kwargs["max_completion_tokens"] = kwargs.pop("max_tokens")
 
                 if "kimi-k" in model.lower():
-                    kwargs["extra_body"] = {"enable_thinking": True}
+                    # Merge rather than assign: a caller-supplied extra_body
+                    # (e.g. provider routing on an inference router) must
+                    # survive, and a caller may set enable_thinking explicitly.
+                    kwargs["extra_body"] = {
+                        "enable_thinking": True,
+                        **(kwargs.get("extra_body") or {}),
+                    }
 
                 response = self.openai_client.chat.completions.create(
                     model=model,

--- a/tests/test_extra_body_merge.py
+++ b/tests/test_extra_body_merge.py
@@ -1,0 +1,59 @@
+"""extra_body supplied by a caller must survive the kimi-k thinking default."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from mobile_world.agents.base import BaseAgent
+
+
+class _Agent(BaseAgent):
+    def __init__(self):
+        # Bypass BaseAgent.__init__: only the client is needed here.
+        self.openai_client = MagicMock()
+
+    def predict(self, *a, **k):  # abstract in BaseAgent
+        raise NotImplementedError
+
+
+def _response(text="ok"):
+    msg = SimpleNamespace(content=text, reasoning_content=None)
+    return SimpleNamespace(choices=[SimpleNamespace(message=msg, finish_reason="stop")], usage=None)
+
+
+def _sent_kwargs(agent):
+    return agent.openai_client.chat.completions.create.call_args.kwargs
+
+
+def test_caller_extra_body_is_preserved_for_kimi():
+    agent = _Agent()
+    agent.openai_client.chat.completions.create.return_value = _response()
+    agent._log_openai_usage = MagicMock()
+
+    routing = {"provider": {"only": ["some-provider"], "allow_fallbacks": False}}
+    agent.openai_chat_completions_create(
+        model="moonshotai/kimi-k2.5", messages=[], extra_body=routing
+    )
+
+    sent = _sent_kwargs(agent)["extra_body"]
+    assert sent["provider"] == routing["provider"], "caller's routing was dropped"
+    assert sent["enable_thinking"] is True, "thinking default was lost"
+
+
+def test_caller_can_disable_thinking():
+    agent = _Agent()
+    agent.openai_client.chat.completions.create.return_value = _response()
+    agent._log_openai_usage = MagicMock()
+
+    agent.openai_chat_completions_create(
+        model="moonshotai/kimi-k2.5", messages=[], extra_body={"enable_thinking": False}
+    )
+    assert _sent_kwargs(agent)["extra_body"]["enable_thinking"] is False
+
+
+def test_no_extra_body_still_enables_thinking():
+    agent = _Agent()
+    agent.openai_client.chat.completions.create.return_value = _response()
+    agent._log_openai_usage = MagicMock()
+
+    agent.openai_chat_completions_create(model="moonshotai/kimi-k2.5", messages=[])
+    assert _sent_kwargs(agent)["extra_body"] == {"enable_thinking": True}


### PR DESCRIPTION
**Phenomenon.** Any `extra_body` a caller passes to `openai_chat_completions_create` is dropped for model ids containing `kimi-k`. On an inference router, that includes provider routing — a request pinned with `{"provider": {"only": [...], "allow_fallbacks": false}}` is instead routed by the default policy. Verified by reading the served provider back off the response: three near-identical pinned requests were answered by three different providers.

**Cause.** `agents/base.py:106` assigns rather than merges:

```python
if "kimi-k" in model.lower():
    kwargs["extra_body"] = {"enable_thinking": True}
```

**Change.** Merge the thinking default into whatever the caller supplied, with the caller's keys winning. Behaviour with no `extra_body` is unchanged (`{"enable_thinking": True}` is still sent); a caller can now also set `enable_thinking` explicitly. Three tests added under `tests/`; they fail on `main` and pass with the change.

Minimal reproduction (any OpenAI-compatible client):

```python
agent.openai_chat_completions_create(
    model="moonshotai/kimi-k2.5", messages=[...],
    extra_body={"provider": {"only": ["deepinfra"], "allow_fallbacks": False}},
)
# main: request body contains only {"enable_thinking": true}; routing is gone
```
